### PR TITLE
Fix Hive-Engine pagination so high-ID tokens (e.g. PAKX) are not dropped

### DIFF
--- a/pizza-discord-bot.py
+++ b/pizza-discord-bot.py
@@ -7,7 +7,6 @@ import discord
 from discord import app_commands
 from discord.ext import commands, tasks
 import hiveengine
-from hiveengine.wallet import Wallet
 import json as json_lib
 import logging
 import os
@@ -106,9 +105,14 @@ async def bal(ctx: discord.Interaction, wallet: str, symbol: str = ''):
         delegation_in = acc.get_token_power() + delegation_out - staked
 
     else:
-        # hive engine token
-        wallet_token_info = Wallet(
-            wallet, blockchain_instance=get_hive_instance(), api=get_hiveengine_instance()).get_token(symbol)
+        # hive engine token — use find_one (single targeted RPC call) to avoid
+        # the 1000-result page limit that Wallet.get_balances() hits for tokens
+        # with a high internal ID (e.g. PAKX).
+        results = get_hiveengine_instance().find_one(
+            "tokens", "balances",
+            query={"account": wallet, "symbol": symbol},
+        )
+        wallet_token_info = results[0] if results else None
 
         if not wallet_token_info:
             balance = 0
@@ -150,11 +154,14 @@ async def bals(ctx: discord.Interaction, wallet: str):
     wallet_token_info = None
 
     try:
-        wallet_token_info = Wallet(
-            wallet, blockchain_instance=get_hive_instance(), api=get_hiveengine_instance())
+        beem.account.Account(wallet, blockchain_instance=get_hive_instance())
     except beem.exceptions.AccountDoesNotExistsException:
         await ctx.response.send_message('Error: the wallet doesnt exist.')
         return
+
+    # Paginate past the 1000-result cap so tokens with a high internal ID
+    # (e.g. PAKX) are not silently dropped.
+    wallet_token_info = get_wallet_balances(wallet)
 
     # sort by stake then balance
     wallet_token_info.sort(key=lambda elem: float(

--- a/tests/test_utils_hiveengine.py
+++ b/tests/test_utils_hiveengine.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock, patch
 from utils_hiveengine import (
     get_market_history,
     get_token_holders,
+    get_wallet_balances,
     get_hiveengine_instance,
     get_hiveengine_market_instance,
 )
@@ -60,6 +61,52 @@ class TestGetTokenHolders:
 
         result = get_token_holders('PIZZA')
         assert len(result) == 1001
+
+
+class TestGetWalletBalances:
+    def test_single_page(self):
+        mock_api = MagicMock()
+        mock_api.find.return_value = [
+            {'symbol': 'PIZZA', 'balance': '10'},
+            {'symbol': 'BEE', 'balance': '5'},
+        ]
+        result = get_wallet_balances('alice', api=mock_api)
+        assert len(result) == 2
+        mock_api.find.assert_called_once_with(
+            'tokens', 'balances', query={'account': 'alice'}, limit=1000, offset=0)
+
+    def test_multi_page(self):
+        mock_api = MagicMock()
+        page1 = [{'symbol': f'TOK{i}', 'balance': '1'} for i in range(1000)]
+        page2 = [{'symbol': 'PAKX', 'balance': '42'}]
+        mock_api.find.side_effect = [page1, page2]
+        result = get_wallet_balances('alice', api=mock_api)
+        assert len(result) == 1001
+        assert result[-1]['symbol'] == 'PAKX'
+
+    def test_single_result_dict_unwrap(self):
+        """Api.find() returns a dict (not a list) when there is exactly one result."""
+        mock_api = MagicMock()
+        mock_api.find.return_value = {'symbol': 'PAKX', 'balance': '42'}
+        result = get_wallet_balances('alice', api=mock_api)
+        assert len(result) == 1
+        assert result[0]['symbol'] == 'PAKX'
+
+    def test_last_page_single_dict_unwrap(self):
+        """Last page has exactly 1 result — Api.find() returns a dict, not a list."""
+        mock_api = MagicMock()
+        page1 = [{'symbol': f'TOK{i}', 'balance': '1'} for i in range(1000)]
+        page2 = {'symbol': 'PAKX', 'balance': '42'}  # dict, not list
+        mock_api.find.side_effect = [page1, page2]
+        result = get_wallet_balances('alice', api=mock_api)
+        assert len(result) == 1001
+        assert result[-1]['symbol'] == 'PAKX'
+
+    def test_empty_wallet(self):
+        mock_api = MagicMock()
+        mock_api.find.return_value = []
+        result = get_wallet_balances('newaccount', api=mock_api)
+        assert result == []
 
 
 class TestGetInstances:

--- a/utils_hiveengine.py
+++ b/utils_hiveengine.py
@@ -49,6 +49,36 @@ def get_market_history(symbol: str,
     return orders
 
 
+def get_wallet_balances(account: str,
+                        api: Optional[Api] = None) -> List[Dict]:
+    """Get all Hive-Engine token balances for an account.
+
+    Paginates past the API's 1000-row limit and handles the library quirk
+    where Api.find() unwraps a single-element result list into a plain dict.
+    """
+    if api is None:
+        api = get_hiveengine_instance()
+    balance_count = 1000
+    balances: List[Dict] = []
+    while balance_count == 1000:
+        response = api.find(
+            "tokens", "balances",
+            query={"account": account},
+            limit=1000,
+            offset=len(balances),
+        )
+        if isinstance(response, dict):
+            # Api.find() unwraps a single-element list to a dict
+            balances.append(response)
+            balance_count = 1
+        elif response:
+            balances.extend(response)
+            balance_count = len(response)
+        else:
+            balance_count = 0
+    return balances
+
+
 def get_token_holders(symbol: str,
                       api: Optional[Api] = None) -> List[Dict]:
     """Get a list of wallets holding a Hive-Engine token."""


### PR DESCRIPTION
## Summary
- `Api.find()` defaults to `limit=1000, offset=0` with no pagination — tokens whose internal `_id` > 1000 were silently missing from `/bal` and `/bals` responses
- `/bal` now uses `Api.find_one()` (a targeted `findOne` RPC call by account+symbol) instead of constructing a full `Wallet` object and searching its cached 1000-result list
- `/bals` now uses a new `get_wallet_balances()` helper in `utils_hiveengine.py` that manually paginates and handles a library quirk where `Api.find()` unwraps single-element result lists to a plain `dict` instead of a list (which caused silent data corruption in `find_all()`)

## Test plan
- [ ] Run `source venv/bin/activate && python -m pytest tests/ --cov --cov-report=term-missing` — all 44 tests pass, coverage ≥ 75%
- [ ] Test `/bal <wallet> PAKX` for a wallet known to hold PAKX — should show correct balance instead of 0
- [ ] Test `/bals <wallet>` for a wallet with many tokens — PAKX should appear in results
- [ ] Test `/bal <wallet> PIZZA` for a normal token — should still work correctly
- [ ] Test `/bals nonexistent-wallet` — should still return "Error: the wallet doesnt exist."